### PR TITLE
:tada: Badge 컴포넌트 구현

### DIFF
--- a/src/components/ui/Badge/Badge.stories.tsx
+++ b/src/components/ui/Badge/Badge.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Badge } from './Badge'
+
+const meta = {
+  title: 'UI/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Badge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Normal: Story = {
+  args: {
+    variant: 'gradation',
+    size: 'sm',
+    children: '거래성사',
+  },
+}

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full px-2 font-medium',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-primary-color text-white',
+        secondary: 'bg-secondary-color text-white',
+        gradation: 'bg-gradient-primary text-white',
+        information: 'bg-background-secondary-color text-black',
+      },
+      size: {
+        sm: 'h-[18px] text-xs',
+        lg: 'h-6 text-sm',
+      },
+    },
+    defaultVariants: {
+      variant: 'information',
+      size: 'sm',
+    },
+  },
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+const Badge = ({ className, variant, size, ...props }: BadgeProps) => {
+  return (
+    <div
+      className={cn(badgeVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+}
+
+Badge.displayName = 'Badge'
+
+export { Badge, badgeVariants }

--- a/src/components/ui/Badge/index.tsx
+++ b/src/components/ui/Badge/index.tsx
@@ -1,0 +1,3 @@
+import { Badge } from './Badge'
+
+export default Badge


### PR DESCRIPTION
## - 목적

관련 티켓 번호: 33

- Bage 컴포넌트 구현했습니다!

<br>

## - 주요 변경 사항

- shadcn/ui의 Badge 컴포넌트를 참조했습니다

## 기타 사항 (선택)

- 카드안에서 Badge 쓰실 때 variant(색상 4종류), size(크기 2종류)를 지정해주시면 됩니다.

<br>

## - 스크린샷 (선택)
![image](https://github.com/team-nabi/nabi-market-client/assets/61399141/0fba0069-b3cf-4ff9-93f2-3459787ba074)

