### PR TITLE
:bug: 카드 컴포넌트 UI 버그, 무한 스크롤 버그 수정, 각 카드 컴포넌트 key 대신 value 렌더링 하기

### DIFF
--- a/src/app/(root)/(routes)/mypage/mycards/components/my-card/MyCard.tsx
+++ b/src/app/(root)/(routes)/mypage/mycards/components/my-card/MyCard.tsx
@@ -2,7 +2,9 @@ import { formatDistanceToNow } from 'date-fns'
 import koLocale from 'date-fns/locale/ko'
 import Image from 'next/image'
 import Link from 'next/link'
-import Badge from '@/components/ui/badge'
+import ReservedBadge from '@/components/domain/badge/reserved-badge'
+import TradeAvailableBadge from '@/components/domain/badge/trade-available-badge'
+import TradeCompleteBadge from '@/components/domain/badge/trade-complete-badge'
 import { Card, CardFlex, CardImage, CardText } from '@/components/ui/card'
 import AppPath from '@/config/appPath'
 import Assets from '@/config/assets'
@@ -25,10 +27,6 @@ const MoveToSuggestCheckPageButton = ({ cardId }: { cardId: number }) => (
     </CardFlex>
   </Link>
 )
-
-const TradeAvailableBadge = () => <Badge variant={'primary'}>거래가능</Badge>
-const ReservedBadge = () => <Badge variant={'secondary'}>예약중</Badge>
-const TradeCompleteBadge = () => <Badge variant={'gradation'}>거래성사</Badge>
 
 type MyCardProps = {
   card: CardInfo
@@ -64,9 +62,18 @@ const MyCard = ({
             />
           </div>
 
-          <CardFlex direction={'col'} justify={'between'} className="h-full">
+          <CardFlex
+            direction={'col'}
+            justify={'between'}
+            className="h-full w-2/3"
+          >
             <CardFlex align={'center'} gap={'space'}>
-              <CardText type={'title'}>{cardTitle}</CardText>
+              <CardText
+                type={'title'}
+                className="whitespace-nowrap overflow-hidden overflow-ellipsis"
+              >
+                {cardTitle}
+              </CardText>
               {status === 'TRADE_AVAILABLE' ? (
                 <TradeAvailableBadge />
               ) : status === 'RESERVED' ? (
@@ -75,7 +82,12 @@ const MyCard = ({
                 <TradeCompleteBadge />
               )}
             </CardFlex>
-            <CardText type={'description'}>{itemName}</CardText>
+            <CardText
+              type={'description'}
+              className="whitespace-nowrap overflow-hidden overflow-ellipsis"
+            >
+              {itemName}
+            </CardText>
             <CardText type={'description'}>{priceRange}</CardText>
             <CardFlex gap={'space'}>
               {status === 'TRADE_AVAILABLE' ? (

--- a/src/app/(root)/(routes)/mypage/mycards/components/my-card/MyCard.tsx
+++ b/src/app/(root)/(routes)/mypage/mycards/components/my-card/MyCard.tsx
@@ -8,7 +8,9 @@ import TradeCompleteBadge from '@/components/domain/badge/trade-complete-badge'
 import { Card, CardFlex, CardImage, CardText } from '@/components/ui/card'
 import AppPath from '@/config/appPath'
 import Assets from '@/config/assets'
+import { PRICE_RANGE_OBJS } from '@/constants/card'
 import type { Card as CardInfo } from '@/types/card'
+import { getValueByKey } from '@/utils/getValueByKey'
 
 const MoveToItemListPageButton = ({ priceRange }: { priceRange: string }) => (
   <Link href={`${AppPath.cards()}?priceRange=${priceRange}`}>
@@ -88,7 +90,9 @@ const MyCard = ({
             >
               {itemName}
             </CardText>
-            <CardText type={'description'}>{priceRange}</CardText>
+            <CardText type={'description'}>
+              {getValueByKey(PRICE_RANGE_OBJS, priceRange)}
+            </CardText>
             <CardFlex gap={'space'}>
               {status === 'TRADE_AVAILABLE' ? (
                 <>

--- a/src/app/(root)/(routes)/mypage/suggestions/[myCardId]/components/my-card-description-section/MyCardDescriptionSection.tsx
+++ b/src/app/(root)/(routes)/mypage/suggestions/[myCardId]/components/my-card-description-section/MyCardDescriptionSection.tsx
@@ -5,7 +5,9 @@ import ReservedBadge from '@/components/domain/badge/reserved-badge'
 import TradeAvailableBadge from '@/components/domain/badge/trade-available-badge'
 import { CardFlex, CardImage, CardText } from '@/components/ui/card'
 import AppPath from '@/config/appPath'
+import { PRICE_RANGE_OBJS } from '@/constants/card'
 import { CardDetail } from '@/types/card'
+import { getValueByKey } from '@/utils/getValueByKey'
 
 type MyCardDescriptionSection = {
   card: CardDetail
@@ -65,7 +67,9 @@ const MyCardDescriptionSection = ({
           >
             {itemName}
           </CardText>
-          <CardText type={'description'}>{priceRange}</CardText>
+          <CardText type={'description'}>
+            {getValueByKey(PRICE_RANGE_OBJS, priceRange)}
+          </CardText>
           <CardText type={'date'}>
             {formatDistanceToNow(new Date(createdAt), { locale: koLocale })}
           </CardText>

--- a/src/app/(root)/(routes)/mypage/suggestions/[myCardId]/components/my-card-description-section/MyCardDescriptionSection.tsx
+++ b/src/app/(root)/(routes)/mypage/suggestions/[myCardId]/components/my-card-description-section/MyCardDescriptionSection.tsx
@@ -1,13 +1,11 @@
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import koLocale from 'date-fns/locale/ko'
 import Link from 'next/link'
-import Badge from '@/components/ui/badge'
+import ReservedBadge from '@/components/domain/badge/reserved-badge'
+import TradeAvailableBadge from '@/components/domain/badge/trade-available-badge'
 import { CardFlex, CardImage, CardText } from '@/components/ui/card'
 import AppPath from '@/config/appPath'
 import { CardDetail } from '@/types/card'
-
-const TradeAvailableBadge = () => <Badge variant={'primary'}>거래가능</Badge>
-const ReservedBadge = () => <Badge variant={'secondary'}>예약중</Badge>
 
 type MyCardDescriptionSection = {
   card: CardDetail
@@ -49,14 +47,24 @@ const MyCardDescriptionSection = ({
           className="w-2/3 h-full"
         >
           <CardFlex align={'center'} gap={'space'}>
-            <CardText type={'title'}>{cardTitle}</CardText>
+            <CardText
+              type={'title'}
+              className="whitespace-nowrap overflow-hidden overflow-ellipsis"
+            >
+              {cardTitle}
+            </CardText>
             {status === 'TRADE_AVAILABLE' ? (
               <TradeAvailableBadge />
             ) : (
               <ReservedBadge />
             )}
           </CardFlex>
-          <CardText type={'description'}>{itemName}</CardText>
+          <CardText
+            type={'description'}
+            className="whitespace-nowrap overflow-hidden overflow-ellipsis"
+          >
+            {itemName}
+          </CardText>
           <CardText type={'description'}>{priceRange}</CardText>
           <CardText type={'date'}>
             {formatDistanceToNow(new Date(createdAt), { locale: koLocale })}

--- a/src/app/(root)/(routes)/mypage/suggestions/[myCardId]/components/my-suggestion-card/MySuggestionCard.tsx
+++ b/src/app/(root)/(routes)/mypage/suggestions/[myCardId]/components/my-suggestion-card/MySuggestionCard.tsx
@@ -5,9 +5,11 @@ import { useParams } from 'next/navigation'
 import Button from '@/components/ui/button'
 import { CardFlex, CardText, Card, CardImage } from '@/components/ui/card/Card'
 import Assets from '@/config/assets'
+import { PRICE_RANGE_OBJS } from '@/constants/card'
 import { useMySuggestionUpdateMutation } from '@/hooks/api/mutations/useMySuggestionUpdateMutation'
 import { Card as CardInfo } from '@/types/card'
 import { DirectionType, Suggestion, SuggestionType } from '@/types/suggestion'
+import { getValueByKey } from '@/utils/getValueByKey'
 
 const SuggestionButtons = ({
   handleMySuggestionUpdate,
@@ -123,7 +125,9 @@ const MySuggestionCard = ({
             >
               {itemName}
             </CardText>
-            <CardText type={'description'}>{priceRange}</CardText>
+            <CardText type={'description'}>
+              {getValueByKey(PRICE_RANGE_OBJS, priceRange)}
+            </CardText>
             <CardFlex gap={'space'}>
               {suggestionStatus === 'WAITING' ? (
                 directionType === 'RECEIVE' ? (

--- a/src/app/(root)/(routes)/mypage/suggestions/[myCardId]/components/my-suggestion-card/MySuggestionCard.tsx
+++ b/src/app/(root)/(routes)/mypage/suggestions/[myCardId]/components/my-suggestion-card/MySuggestionCard.tsx
@@ -106,9 +106,23 @@ const MySuggestionCard = ({
             />
           </div>
 
-          <CardFlex direction={'col'} justify={'between'} className="h-full">
-            <CardText type={'title'}>{cardTitle}</CardText>
-            <CardText type={'description'}>{itemName}</CardText>
+          <CardFlex
+            direction={'col'}
+            justify={'between'}
+            className="h-full w-2/3"
+          >
+            <CardText
+              type={'title'}
+              className="whitespace-nowrap overflow-hidden overflow-ellipsis"
+            >
+              {cardTitle}
+            </CardText>
+            <CardText
+              type={'description'}
+              className="whitespace-nowrap overflow-hidden overflow-ellipsis"
+            >
+              {itemName}
+            </CardText>
             <CardText type={'description'}>{priceRange}</CardText>
             <CardFlex gap={'space'}>
               {suggestionStatus === 'WAITING' ? (

--- a/src/components/domain/badge/reserved-badge/ReservedBadge.tsx
+++ b/src/components/domain/badge/reserved-badge/ReservedBadge.tsx
@@ -1,0 +1,8 @@
+import Badge from '@/components/ui/badge'
+
+const ReservedBadge = () => (
+  <Badge variant={'secondary'} className="min-w-fit">
+    예약중
+  </Badge>
+)
+export default ReservedBadge

--- a/src/components/domain/badge/reserved-badge/index.tsx
+++ b/src/components/domain/badge/reserved-badge/index.tsx
@@ -1,0 +1,3 @@
+import ReservedBadge from './ReservedBadge'
+
+export default ReservedBadge

--- a/src/components/domain/badge/trade-available-badge/TradeAvailableBadge.tsx
+++ b/src/components/domain/badge/trade-available-badge/TradeAvailableBadge.tsx
@@ -1,0 +1,8 @@
+import Badge from '@/components/ui/badge'
+
+const TradeAvailableBadge = () => (
+  <Badge variant={'primary'} className="min-w-fit">
+    거래가능
+  </Badge>
+)
+export default TradeAvailableBadge

--- a/src/components/domain/badge/trade-available-badge/index.tsx
+++ b/src/components/domain/badge/trade-available-badge/index.tsx
@@ -1,0 +1,3 @@
+import TradeAvailableBadge from './TradeAvailableBadge'
+
+export default TradeAvailableBadge

--- a/src/components/domain/badge/trade-complete-badge/TradeCompleteBadge.tsx
+++ b/src/components/domain/badge/trade-complete-badge/TradeCompleteBadge.tsx
@@ -1,0 +1,8 @@
+import Badge from '@/components/ui/badge'
+
+const TradeCompleteBadge = () => (
+  <Badge variant={'gradation'} className="min-w-fit">
+    거래완료
+  </Badge>
+)
+export default TradeCompleteBadge

--- a/src/components/domain/badge/trade-complete-badge/index.tsx
+++ b/src/components/domain/badge/trade-complete-badge/index.tsx
@@ -1,0 +1,3 @@
+import TradeCompleteBadge from './TradeCompleteBadge'
+
+export default TradeCompleteBadge

--- a/src/components/domain/card/trade-history-card/TradeHistoryCard.tsx
+++ b/src/components/domain/card/trade-history-card/TradeHistoryCard.tsx
@@ -21,7 +21,10 @@ const SubCard = ({
         className="rounded"
       />
     </div>
-    <CardText type={'description'} className="font-bold">
+    <CardText
+      type={'description'}
+      className="font-bold whitespace-nowrap overflow-hidden overflow-ellipsis"
+    >
       {itemName}
     </CardText>
     <CardText type={'icon'}>{priceRange}</CardText>

--- a/src/components/domain/card/trade-history-card/TradeHistoryCard.tsx
+++ b/src/components/domain/card/trade-history-card/TradeHistoryCard.tsx
@@ -27,7 +27,9 @@ const SubCard = ({
     >
       {itemName}
     </CardText>
-    <CardText type={'icon'}>{priceRange}</CardText>
+    <CardText type={'icon'}>
+      {getValueByKey(PRICE_RANGE_OBJS, priceRange)}
+    </CardText>
   </CardFlex>
 )
 
@@ -47,7 +49,7 @@ const TradeHistoryCard = ({
         <SubCard
           thumbnail={fromCard.thumbnail}
           itemName={fromCard.itemName}
-          priceRange={getValueByKey(PRICE_RANGE_OBJS, fromCard.priceRange)}
+          priceRange={fromCard.priceRange}
         />
         <CardFlex direction={'col'} align={'center'}>
           <CardImage alt={'거래 완료 이미지'} src={Assets.tradeComplete} />
@@ -58,7 +60,7 @@ const TradeHistoryCard = ({
         <SubCard
           thumbnail={toCard.thumbnail}
           itemName={toCard.itemName}
-          priceRange={getValueByKey(PRICE_RANGE_OBJS, toCard.priceRange)}
+          priceRange={toCard.priceRange}
         />
       </CardFlex>
     </Card>

--- a/src/components/domain/card/trade-status-card/TradeStatusCard.tsx
+++ b/src/components/domain/card/trade-status-card/TradeStatusCard.tsx
@@ -1,18 +1,16 @@
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import koLocale from 'date-fns/locale/ko'
 import Link from 'next/link'
-import Badge from '@/components/ui/badge'
 import Card from '@/components/ui/card'
 import { CardFlex, CardImage, CardText } from '@/components/ui/card'
 import AppPath from '@/config/appPath'
 import { Card as CardInfo } from '@/types/card'
+import ReservedBadge from '../../badge/reserved-badge'
+import TradeAvailableBadge from '../../badge/trade-available-badge'
 
 type TradeStatusCardProps = {
   card: CardInfo
 }
-
-const TradeAvailableBadge = () => <Badge variant={'primary'}>거래가능</Badge>
-const ReservedBadge = () => <Badge variant={'secondary'}>예약중</Badge>
 
 const TradeStatusCard = ({
   card: {
@@ -44,16 +42,30 @@ const TradeStatusCard = ({
             />
           </div>
 
-          <CardFlex direction={'col'} justify={'between'} className="h-full">
+          <CardFlex
+            direction={'col'}
+            justify={'between'}
+            className="h-full w-2/3"
+          >
             <CardFlex align={'center'} gap={'space'}>
-              <CardText type={'title'}>{cardTitle}</CardText>
+              <CardText
+                type={'title'}
+                className="whitespace-nowrap overflow-hidden overflow-ellipsis"
+              >
+                {cardTitle}
+              </CardText>
               {status === 'TRADE_AVAILABLE' ? (
                 <TradeAvailableBadge />
               ) : (
                 <ReservedBadge />
               )}
             </CardFlex>
-            <CardText type={'description'}>{itemName}</CardText>
+            <CardText
+              type={'description'}
+              className="whitespace-nowrap overflow-hidden overflow-ellipsis"
+            >
+              {itemName}
+            </CardText>
             <CardText type={'description'}>{priceRange}</CardText>
             <CardText type={'date'}>
               {formatDistanceToNow(new Date(createdAt), { locale: koLocale })}

--- a/src/components/domain/card/trade-status-card/TradeStatusCard.tsx
+++ b/src/components/domain/card/trade-status-card/TradeStatusCard.tsx
@@ -4,7 +4,9 @@ import Link from 'next/link'
 import Card from '@/components/ui/card'
 import { CardFlex, CardImage, CardText } from '@/components/ui/card'
 import AppPath from '@/config/appPath'
+import { PRICE_RANGE_OBJS } from '@/constants/card'
 import { Card as CardInfo } from '@/types/card'
+import { getValueByKey } from '@/utils/getValueByKey'
 import ReservedBadge from '../../badge/reserved-badge'
 import TradeAvailableBadge from '../../badge/trade-available-badge'
 
@@ -66,7 +68,9 @@ const TradeStatusCard = ({
             >
               {itemName}
             </CardText>
-            <CardText type={'description'}>{priceRange}</CardText>
+            <CardText type={'description'}>
+              {getValueByKey(PRICE_RANGE_OBJS, priceRange)}
+            </CardText>
             <CardText type={'date'}>
               {formatDistanceToNow(new Date(createdAt), { locale: koLocale })}
             </CardText>

--- a/src/config/apiEndPoint.ts
+++ b/src/config/apiEndPoint.ts
@@ -1,3 +1,4 @@
+import { COMMON_PAGE_SIZE } from '@/constants/pageSize'
 import { GetCardListReq, GetMyCardListReq } from '@/services/card/card'
 import { GetMyTradeHistoryListReq } from '@/services/history/history'
 import { GetMySuggestionListReq } from '@/services/suggestion/suggestion'
@@ -20,12 +21,12 @@ const ApiEndPoint = {
       cardTitle,
       cursorId,
       status: 'TRADE_AVAILABLE,RESERVED',
-      size: '5',
+      size: COMMON_PAGE_SIZE,
     })}`,
   getMyCardList: ({ tradeStatus, cursorId }: GetMyCardListReq) => {
     return `/cards/${tradeStatus}/my-cards?${getQueryParams({
       cursorId,
-      size: '5',
+      size: COMMON_PAGE_SIZE,
     })}`
   },
   postDibs: (cardId: number) => `/dibs/${cardId}`,
@@ -41,7 +42,7 @@ const ApiEndPoint = {
     return `/suggestions/${directionType}/${suggestionType}/${cardId}/?${getQueryParams(
       {
         cursorId,
-        size: '5',
+        size: COMMON_PAGE_SIZE,
       },
     )}`
   },
@@ -53,7 +54,7 @@ const ApiEndPoint = {
   getMyTradeHistoryList: ({ cursorId }: GetMyTradeHistoryListReq) => {
     return `/complete-requests/user/?${getQueryParams({
       cursorId,
-      size: '5',
+      size: COMMON_PAGE_SIZE,
     })}`
   },
   postImageFile: () => '/s3/upload/single',

--- a/src/constants/pageSize.ts
+++ b/src/constants/pageSize.ts
@@ -1,1 +1,2 @@
 export const RECENT_HISTORY_SIZE = 5
+export const COMMON_PAGE_SIZE = 10

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,5 +37,10 @@ export async function middleware(request: NextRequest) {
 
 // See "Matching Paths" below to learn more
 export const config = {
-  matcher: ['/test-auth-only'],
+  matcher: [
+    '/test-auth-only',
+    '/mypage/mycards',
+    '/mypage/suggestions',
+    '/mypage/histories',
+  ],
 }


### PR DESCRIPTION
## - 목적

관련 티켓 번호: 270

-

<br>

## - 주요 변경 사항

- 카드 컴포넌트의 텍스트가 특정 길이를 넘어가면 UI가 깨지는 스타일 버그를 수정했습니다.
- PriceRangeObjs를 각 카드 컴포넌트에 적용했습니다.
- InterSectionObserver 높이로 인한 비동작 오류를 PAGE_SIZE를 10으로 설정하여 응급조치 했습니다.

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
