### PR TITLE
:tada: 리다이랙트 및 라우팅 추가 + 버그 수정

### DIFF
--- a/src/app/(root)/(routes)/cards/[cardId]/components/description-section/DescriptionSection.tsx
+++ b/src/app/(root)/(routes)/cards/[cardId]/components/description-section/DescriptionSection.tsx
@@ -1,6 +1,8 @@
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import koLocale from 'date-fns/locale/ko'
+import { useRouter } from 'next/navigation'
 import Badge from '@/components/ui/badge'
+import AppPath from '@/config/appPath'
 import { CATEGORY_OBJS, TRADE_STATUS_OBJS } from '@/constants/card'
 import { useAuth } from '@/contexts/AuthProvider'
 import { TYPOGRAPHY } from '@/styles/sizes'
@@ -36,6 +38,7 @@ const DescriptionSection = ({
 }: DescriptionSectionProps) => {
   const { isLoggedIn } = useAuth()
   const { currentUser } = useAuth()
+  const router = useRouter()
 
   const isMyItem = currentUser?.userId === authorId
 
@@ -68,7 +71,14 @@ const DescriptionSection = ({
             TYPOGRAPHY.description,
           )}
         >
-          <u>{getValueByKey(CATEGORY_OBJS, category)}</u>
+          <u
+            className="cursor-pointer"
+            onClick={() =>
+              router.push(`${AppPath.cards()}?category=${category}`)
+            }
+          >
+            {getValueByKey(CATEGORY_OBJS, category)}
+          </u>
         </p>
         <p className={cn('text-text-secondary-color', TYPOGRAPHY.description)}>
           {formatDistanceToNow(new Date(createdAt), {

--- a/src/app/(root)/(routes)/cards/[cardId]/components/description-section/DescriptionSection.tsx
+++ b/src/app/(root)/(routes)/cards/[cardId]/components/description-section/DescriptionSection.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/contexts/AuthProvider'
 import { TYPOGRAPHY } from '@/styles/sizes'
 import { CardDetail } from '@/types/card'
 import { cn } from '@/utils'
+import { getQueryParams } from '@/utils/getQueryParams'
 import { getValueByKey } from '@/utils/getValueByKey'
 import Dibs from './Dibs'
 import MoreButton from './MoreButton'
@@ -74,7 +75,7 @@ const DescriptionSection = ({
           <u
             className="cursor-pointer"
             onClick={() =>
-              router.push(`${AppPath.cards()}?category=${category}`)
+              router.push(`${AppPath.cards()}?${getQueryParams({ category })}`)
             }
           >
             {getValueByKey(CATEGORY_OBJS, category)}

--- a/src/app/(root)/(routes)/cards/[cardId]/components/trade-section/SuggestList.tsx
+++ b/src/app/(root)/(routes)/cards/[cardId]/components/trade-section/SuggestList.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from 'react'
 import { useRouter } from 'next/navigation'
+import Loading from '@/app/loading'
 import SuggestCard from '@/components/domain/card/suggest-card'
 import NoData from '@/components/domain/no-data'
 import { Tabs, TabsTrigger, TabsList, TabsContent } from '@/components/ui/tabs'
@@ -51,19 +53,21 @@ const SuggestList = ({ pokeAvailable, toCardId }: SuggestListProps) => {
         <TabsTrigger value="OFFER">오퍼하기</TabsTrigger>
         <TabsTrigger value="POKE">찔러보기</TabsTrigger>
       </TabsList>
-      {['OFFER', 'POKE'].map((type) => (
-        <TabsContent
-          key={type}
-          value={type}
-          className="flex flex-col data-[state=inactive]:hidden h-[402px] overflow-y-auto pr-2"
-        >
-          {!pokeAvailable && type === 'POKE' ? (
-            <PokeUnavailableInfo />
-          ) : (
-            filterData(type)
-          )}
-        </TabsContent>
-      ))}
+      <Suspense fallback={<Loading />}>
+        {['OFFER', 'POKE'].map((type) => (
+          <TabsContent
+            key={type}
+            value={type}
+            className="flex flex-col data-[state=inactive]:hidden h-[402px] overflow-y-auto pr-2"
+          >
+            {!pokeAvailable && type === 'POKE' ? (
+              <PokeUnavailableInfo />
+            ) : (
+              filterData(type)
+            )}
+          </TabsContent>
+        ))}
+      </Suspense>
     </Tabs>
   )
 }

--- a/src/app/(root)/(routes)/chatrooms/[chatRoomId]/loading.tsx
+++ b/src/app/(root)/(routes)/chatrooms/[chatRoomId]/loading.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Lottie from 'react-lottie-player'
-import lottieJson from '../../public/loading.json'
+import lottieJson from '../../../../../../public/loading.json'
 
 const Loading = () => {
   return (
@@ -16,7 +16,7 @@ const Loading = () => {
             height: '100%',
           }}
         />
-        <p className="font- text-[20px]">잠시만 기다려 주세요.</p>
+        <p className="font- text-[20px]">채팅방을 불러오는 중입니다.</p>
       </div>
     </div>
   )

--- a/src/app/(root)/(routes)/notifications/components/notification-card/NotificationCard.tsx
+++ b/src/app/(root)/(routes)/notifications/components/notification-card/NotificationCard.tsx
@@ -11,8 +11,15 @@ type NotificationCardProps = {
 const NotificationCard = ({
   notification: { content, cardId, read },
 }: NotificationCardProps) => {
+  const isCompleteRequestNotification = content.includes('성사')
   return (
-    <Link href={`${AppPath.mySuggestions(cardId)}`}>
+    <Link
+      href={
+        isCompleteRequestNotification
+          ? `${AppPath.chatRooms()}`
+          : `${AppPath.mySuggestions(cardId)}`
+      }
+    >
       <Card size={'xs'} className="p-4">
         <CardFlex justify={'between'} align={'center'} className="h-full">
           <CardFlex gap={'space'} align={'center'} className="h-full w-2/3">

--- a/src/components/domain/card/suggest-card/SuggestCard.tsx
+++ b/src/components/domain/card/suggest-card/SuggestCard.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import Button from '@/components/ui/button'
 import Card from '@/components/ui/card'
 import { CardFlex, CardImage, CardText } from '@/components/ui/card/Card'
+import AppPath from '@/config/appPath'
 import { PRICE_RANGE_OBJS } from '@/constants/card'
 import { DEFAULT_ITEM_THUMBNAIL_IMG } from '@/constants/image'
 import useSuggestionCreateMutation from '@/hooks/api/mutations/useSuggestionCreateMutation'
@@ -31,7 +33,7 @@ const SuggestCard = ({
   suggestionStatus,
 }: SuggestCardProps) => {
   const { mutate } = useSuggestionCreateMutation(toCardId, fromCardId)
-
+  const router = useRouter()
   const onClickSuggest = async (suggestionType: SuggestionType) => {
     mutate({ suggestionType, fromCardId, toCardId })
   }
@@ -44,12 +46,13 @@ const SuggestCard = ({
         gap={'space'}
         className="h-full"
       >
-        <div className="h-full w-36 relative">
+        <div className="h-full w-36 relative cursor-pointer">
           <CardImage
             src={thumbnail}
             alt="thumbnail"
             layout="fill"
             objectFit="cover"
+            onClick={() => router.push(AppPath.card(String(fromCardId)))}
           />
         </div>
         <CardFlex direction={'col'} justify={'between'} className="h-full grow">

--- a/src/hooks/useDibs.ts
+++ b/src/hooks/useDibs.ts
@@ -1,10 +1,15 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { deleteCardDibs, postCardDibs } from '@/services/card/card'
 import { toast } from './useToast'
 
 const useDibs = (isMyDib: boolean, count: number) => {
+  useEffect(() => {
+    setIsDibsActive(isMyDib)
+    setDibsCount(count)
+  }, [count, isMyDib])
+
   const [isDibsActive, setIsDibsActive] = useState(isMyDib)
   const [dibsCount, setDibsCount] = useState(count)
 


### PR DESCRIPTION
## - 목적

관련 티켓 번호: 359

-

<br>

## - 주요 변경 사항

- 거래성사관련 알림 클릭시 채팅방목록으로 리다이랙트로하도록 수정
- 상세정보페이지에서 카테고리 누르면 카테고리 필터된채로 전체 목록 페이지로 이동 추가
- 제안모달에서 이미지 누르면 상세정보 페이지로 이동하도록 추가
- 찜 뒤로가기&되돌아오기 했을 때 업데이트 안되어있던 버그 수정
- 채팅방 처음 접속시 로딩 되도록 추가

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
