### PR TITLE
:sparkles: 업로드 및 validation 로직 리팩토링 등

### DIFF
--- a/src/app/(root)/(routes)/(home)/components/CategorySection.tsx
+++ b/src/app/(root)/(routes)/(home)/components/CategorySection.tsx
@@ -21,8 +21,6 @@ const CategorySection = () => {
             className="w-8 h-8"
             alt={`category-${v.key}`}
             src={v.image}
-            quality={50}
-            sizes="32px"
             loading="eager"
           />
           <p className={` w-max ${TYPOGRAPHY.description}`}>{v.value}</p>

--- a/src/components/domain/image-uploader/components/UploadBlock.tsx
+++ b/src/components/domain/image-uploader/components/UploadBlock.tsx
@@ -9,12 +9,14 @@ type UploadBlockType = {
   onUploadHandler: (_e: React.ChangeEvent<HTMLInputElement>) => void
   currentPhotoNumber: number
   maxPhotoNumber: number
+  isUploading: boolean
 }
 
 const UploadBlock = ({
   onUploadHandler,
   currentPhotoNumber = 0,
   maxPhotoNumber,
+  isUploading,
 }: UploadBlockType) => {
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -35,7 +37,11 @@ const UploadBlock = ({
             TYPOGRAPHY.description,
             'text-text-secondary-color',
           )}
-        >{`${currentPhotoNumber}/${maxPhotoNumber}`}</span>
+        >
+          {isUploading
+            ? `업로드 중`
+            : `${currentPhotoNumber}/${maxPhotoNumber}`}
+        </span>
       </div>
       <Input
         ref={inputRef}

--- a/src/contexts/ThemeProviderContext.tsx
+++ b/src/contexts/ThemeProviderContext.tsx
@@ -17,7 +17,7 @@ const ThemeProviderContext = ({ children }: ThemeProviderContextProps) => {
   if (!mounted) return null
 
   return (
-    <ThemeProvider attribute="light" enableSystem={false}>
+    <ThemeProvider forcedTheme="light" enableSystem={false}>
       {children}
     </ThemeProvider>
   )

--- a/src/hooks/useValidate.ts
+++ b/src/hooks/useValidate.ts
@@ -21,12 +21,11 @@ const useValidate = () => {
   const validateUserQuery = useQuery({
     queryKey: ['validate', accessToken],
     queryFn: async () => {
-      const token = accessToken
-      if (token) {
-        apiClient.setDefaultHeader('Authorization', token)
-        return getValidateUser()
+      if (!accessToken) {
+        throw new Error('No token found')
       }
-      throw new Error('No token found')
+      apiClient.setDefaultHeader('Authorization', accessToken)
+      return getValidateUser()
     },
     enabled: !!accessToken,
     throwOnError: false,
@@ -35,10 +34,10 @@ const useValidate = () => {
   const reissueTokenQuery = useQuery({
     queryKey: ['reissueAccessToken', refreshToken],
     queryFn: async () => {
-      if (refreshToken) {
-        return reissueAccessToken({ refreshToken })
+      if (!refreshToken) {
+        throw new Error('No refresh token found')
       }
-      throw new Error('No refresh token found')
+      return reissueAccessToken({ refreshToken })
     },
     enabled: !!refreshToken && (validateUserQuery.isError || !accessToken),
     throwOnError: false,

--- a/src/hooks/useValidate.ts
+++ b/src/hooks/useValidate.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import Cookies from 'js-cookie'
 import { usePathname, useRouter } from 'next/navigation'
@@ -8,32 +8,15 @@ import AppPath from '@/config/appPath'
 import { Environment } from '@/config/environment'
 import apiClient from '@/services/apiClient'
 import { getValidateUser, reissueAccessToken } from '@/services/auth/auth'
-import type { User } from '@/types/user'
 import { useToast } from './useToast'
 
 const useValidate = () => {
   const router = useRouter()
-  const { toast } = useToast()
   const pathname = usePathname()
+  const { toast } = useToast()
 
   const accessToken = Cookies.get(Environment.tokenName())
   const refreshToken = Cookies.get(Environment.refreshTokenName())
-
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(() => !!accessToken)
-  const [currentUser, setCurrentUser] = useState<User | null>(() => null)
-
-  const handleTokenRefresh = ({
-    token,
-    expiresInHours = 1,
-  }: {
-    token: string
-    expiresInHours?: number
-  }) => {
-    let expiry = new Date()
-    expiry.setHours(expiry.getHours() + expiresInHours)
-    Cookies.set(Environment.tokenName(), token, { expires: expiry })
-    return token
-  }
 
   const validateUserQuery = useQuery({
     queryKey: ['validate', accessToken],
@@ -61,58 +44,82 @@ const useValidate = () => {
     throwOnError: false,
   })
 
-  const updateLoginState = (userInfo: User) => {
-    setCurrentUser(() => userInfo)
-    setIsLoggedIn(() => !!userInfo)
+  /**
+   *
+   * @description 재발급 된 토큰을 쿠키에 저장합니다.
+   */
+  const handleTokenRefresh = ({
+    token,
+    expiresInHours = 1,
+  }: {
+    token?: string
+    expiresInHours?: number
+  }) => {
+    if (!token) return
+    let expiry = new Date()
+    expiry.setHours(expiry.getHours() + expiresInHours)
+    Cookies.set(Environment.tokenName(), token, { expires: expiry })
     window.location.reload()
   }
 
-  useEffect(() => {
-    if (validateUserQuery.isError) {
-      Cookies.remove(Environment.tokenName())
-      if (!refreshToken || reissueTokenQuery.isError) {
-        router.push(AppPath.login(), { scroll: false })
-        toast({
-          title: '인증 에러',
-          description: '만료되거나 잘못된 토큰입니다. 다시 로그인해주세요.',
-          variant: 'destructive',
-          duration: 3000,
-        })
-      } else if (reissueTokenQuery.data?.data?.accessToken) {
-        handleTokenRefresh({
-          token: reissueTokenQuery.data.data.accessToken,
-        })
-        updateLoginState(validateUserQuery.data?.data?.userInfo)
-      }
-    }
+  const showAuthErrorToast = useCallback(() => {
+    toast({
+      title: '인증 에러',
+      description: '만료되거나 잘못된 토큰입니다. 다시 로그인해주세요.',
+      variant: 'destructive',
+      duration: 3000,
+    })
+  }, [toast])
 
-    if (!accessToken && !!refreshToken) {
-      if (reissueTokenQuery.data?.data?.accessToken) {
-        handleTokenRefresh({
-          token: reissueTokenQuery.data.data.accessToken,
-        })
-        updateLoginState(validateUserQuery.data?.data?.userInfo)
-      }
-    }
+  /**
+   * @description: 세션 만료시 로그인 페이지로 이동합니다.
+   * @description: 리프레시 토큰까지 만료되었을 경우
+   */
+  const handleSessionExpiration = useCallback(() => {
+    Cookies.remove(Environment.tokenName())
+    router.push(AppPath.login(), { scroll: false })
+    showAuthErrorToast()
+  }, [router, showAuthErrorToast])
 
-    if (validateUserQuery.data?.data?.userInfo) {
-      const userInfo = validateUserQuery.data.data.userInfo
-      setCurrentUser(() => userInfo)
-      setIsLoggedIn(() => !!userInfo)
+  /**
+   * @description: 토큰 재발급이 필요한 경우, 재발급 후 새로고침합니다.
+   * @description: 리프레시 토큰까지 만료되었을 경우 handleSessionExpiration 실행
+   */
+  const refreshTokenIfNeeded = useCallback(async () => {
+    if (!refreshToken || reissueTokenQuery.isError) {
+      handleSessionExpiration()
+    } else if (reissueTokenQuery.data?.data?.accessToken) {
+      const newToken = reissueTokenQuery.data.data.accessToken
+      handleTokenRefresh({ token: newToken })
     }
   }, [
-    validateUserQuery.data?.data?.userInfo,
-    reissueTokenQuery.data?.data.accessToken,
-    router,
-    pathname,
-    toast,
-    validateUserQuery.isError,
-    accessToken,
     refreshToken,
     reissueTokenQuery.isError,
+    reissueTokenQuery.data?.data.accessToken,
+    handleSessionExpiration,
   ])
 
-  return { isLoggedIn, currentUser }
+  useEffect(() => {
+    if (validateUserQuery.isError) {
+      refreshTokenIfNeeded()
+    }
+  }, [validateUserQuery.isError, refreshTokenIfNeeded])
+
+  useEffect(() => {
+    if (!accessToken && refreshToken) {
+      handleTokenRefresh({ token: reissueTokenQuery?.data?.data.accessToken })
+    }
+  }, [
+    accessToken,
+    refreshToken,
+    reissueTokenQuery?.data?.data.accessToken,
+    pathname,
+  ])
+
+  return {
+    isLoggedIn: !!accessToken,
+    currentUser: validateUserQuery?.data?.data.userInfo,
+  }
 }
 
 export default useValidate

--- a/src/services/images/index.ts
+++ b/src/services/images/index.ts
@@ -5,11 +5,11 @@ const postImageFile = async (file: File) => {
   const formData = new FormData()
   formData.append('file', file)
 
-  const response = await apiClient.post(
-    ApiEndPoint.postImageFile(),
-    formData,
-    {},
-  )
+  const response: Promise<{
+    code: string
+    data: string
+    messages: string
+  }> = await apiClient.post(ApiEndPoint.postImageFile(), formData, {})
 
   return response
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
     // Or if using `src` directory:
     './src/**/*.{js,ts,jsx,tsx,mdx}',
   ],
-  darkMode: ['class'],
+  darkMode: ['light'],
   theme: {
     screens: {
       xs: { max: '480px' },


### PR DESCRIPTION
## - 목적

관련 티켓 번호: 385, 387, 392

-

<br>

## - 주요 변경 사항

- 385: 제 로컬에서 뭐가 꼬인 것인지 다크모드가 또 말썽이어서 제대로 비활성화 했습니다. 배포 버전이 이상 없는 것으로 봐서는 또 파일명 이슈인지 잘 모르겠네요
- 387: 업로드 컴포넌트를 tanstack query를 사용하여 리팩토링하고, 업로드 중일 때 안내 메세지를 추가했습니다.
- 392: 기존 validation에서 과도한 useEffect 내부 로직을 간소화하고, 의존성에 따라 분리하여 작성했습니다. 불필요한 state를 삭제하고 useCallback을 이용한 렌더링 최적화를 진행했습니다.

## 기타 사항 (선택)

- 원래 fork repo에서 PR을 날리기로 했는데, 제 레포가 배포 중인 레포이기도 하고, 파일명 이슈가 왠지 있는 것 같아 main-jaehee <- develop-jaehee로 PR을 생성하게 됐습니다.
- 때문에 develop-jaehee에서 작업하고 각 티켓은 커밋 단위로 작업했습니다. 양해 부탁드립니다. (다른 의견이나 문제 있으면 언제든지 알려주세요)

<br>

## - 스크린샷 (선택)
